### PR TITLE
Fix Entra redirect issue

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,9 +7,9 @@
       "type": "coreclr",
       "request": "launch",
       "preLaunchTask": "build-web-client",
-      "program": "${workspaceFolder}/apps/App.Web.Client/bin/Debug/net8.0/App.Web.Client.dll", // the entry point for the debugger
+      "program": "${workspaceFolder}/src/apps/App.Web.Client/bin/Debug/net8.0/App.Web.Client.dll", // the entry point for the debugger
       "args": [],
-      "cwd": "${workspaceFolder}/apps/App.Web.Client",
+      "cwd": "${workspaceFolder}/src/apps/App.Web.Client",
       "stopAtEntry": false,
       "console": "internalConsole"
     },
@@ -18,9 +18,9 @@
       "type": "coreclr",
       "request": "launch",
       "preLaunchTask": "build-todo-api",
-      "program": "${workspaceFolder}/apps/App.Api.Todo/bin/Debug/net8.0/App.Api.Todo.dll",
+      "program": "${workspaceFolder}/src/apps/App.Api.Todo/bin/Debug/net8.0/App.Api.Todo.dll",
       "args": [],
-      "cwd": "${workspaceFolder}/apps/App.Api.Todo",
+      "cwd": "${workspaceFolder}/src/apps/App.Api.Todo",
       "stopAtEntry": false,
       "console": "integratedTerminal"
     }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,7 +8,7 @@
       "command": "dotnet",
       "args": [
         "build",
-        "${workspaceFolder}/apps/App.Api.Todo/App.Api.Todo.csproj"
+        "${workspaceFolder}/src/apps/App.Api.Todo/App.Api.Todo.csproj"
       ],
       "problemMatcher": "$msCompile",
       "group": {
@@ -22,7 +22,7 @@
       "command": "dotnet",
       "args": [
         "build",
-        "${workspaceFolder}/apps/App.Web.Client/App.Web.Client.csproj"
+        "${workspaceFolder}/src/apps/App.Web.Client/App.Web.Client.csproj"
       ],
       "problemMatcher": "$msCompile"
     },

--- a/src/apps/App.Api.Todo/Program.cs
+++ b/src/apps/App.Api.Todo/Program.cs
@@ -1,6 +1,7 @@
 using App.Api.Todo.Extensions;
 using HealthChecks.UI.Client;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.HttpOverrides;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -22,6 +23,13 @@ builder.Services
     .AddBusinesServices(builder.Configuration)
     .AddInfrastructureServices(builder.Configuration)
     .ConfigureHealthChecks(builder.Configuration);
+
+builder.Services.Configure<ForwardedHeadersOptions>(options =>
+{
+    options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+    options.KnownNetworks.Clear(); // ACA sets proper headers
+    options.KnownProxies.Clear();
+});
 
 var app = builder.Build();
 

--- a/src/apps/App.Web.Client/Controllers/AccountController.cs
+++ b/src/apps/App.Web.Client/Controllers/AccountController.cs
@@ -38,5 +38,9 @@ namespace App.Web.Client.Controllers
         {
             return View();
         }
+
+        [HttpGet]
+        [AllowAnonymous]
+        public IActionResult Unauthorized() => View();
     }
 }

--- a/src/apps/App.Web.Client/Extensions/ServiceCollectionExtensions.cs
+++ b/src/apps/App.Web.Client/Extensions/ServiceCollectionExtensions.cs
@@ -15,7 +15,10 @@ namespace App.Web.Client.Extensions
     {
         public static IServiceCollection AddCustomAuthentication(this IServiceCollection services, IConfiguration config)
         {
-            services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
+            var useEasyAuth = config.GetValue<bool>("UseEasyAuth");
+            if (!useEasyAuth)
+            {
+                services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
                 .AddCookie(options =>
                 {
                     options.LoginPath = "/Account/Login"; // Optional override
@@ -31,14 +34,15 @@ namespace App.Web.Client.Extensions
                     options.Events.OnRemoteFailure += OnRemoteFailureFunc;
                 });
 
-            services.ConfigureApplicationCookie(options =>
-            {
-                options.Cookie.HttpOnly = true;
-                options.Cookie.SecurePolicy = CookieSecurePolicy.Always; // HTTPS only
-                options.Cookie.SameSite = SameSiteMode.Strict; // or Lax
-                options.ExpireTimeSpan = TimeSpan.FromMinutes(30);
-                options.SlidingExpiration = true;
-            });
+                services.ConfigureApplicationCookie(options =>
+                {
+                    options.Cookie.HttpOnly = true;
+                    options.Cookie.SecurePolicy = CookieSecurePolicy.Always; // HTTPS only
+                    options.Cookie.SameSite = SameSiteMode.Strict; // or Lax
+                    options.ExpireTimeSpan = TimeSpan.FromMinutes(30);
+                    options.SlidingExpiration = true;
+                });
+            }
 
             return services;
         }

--- a/src/apps/App.Web.Client/Program.cs
+++ b/src/apps/App.Web.Client/Program.cs
@@ -1,6 +1,7 @@
 using App.Web.Client.Utilities.Middleware;
 using Microsoft.Identity.Web.UI;
 using App.Web.Client.Extensions;
+using Microsoft.AspNetCore.HttpOverrides;
 
 var builder = WebApplication.CreateBuilder(args);
 var config = builder.Configuration
@@ -15,6 +16,13 @@ builder.Services
 builder.Services
     .AddCustomAuthentication(config)
     .AddInternalServices(config);
+
+builder.Services.Configure<ForwardedHeadersOptions>(options =>
+{
+    options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+    options.KnownNetworks.Clear(); // ACA sets proper headers
+    options.KnownProxies.Clear();
+});
 
 var app = builder.Build();
 

--- a/src/apps/App.Web.Client/Utilities/CustomViewComponent/FooterViewComponent.cs
+++ b/src/apps/App.Web.Client/Utilities/CustomViewComponent/FooterViewComponent.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System.Reflection;
+using Microsoft.AspNetCore.Mvc;
 
 namespace App.Web.Client.Utilities.CustomViewComponent
 {
@@ -6,7 +7,10 @@ namespace App.Web.Client.Utilities.CustomViewComponent
     {
         public IViewComponentResult Invoke()
         {
-            var version = Environment.GetEnvironmentVariable("APP_VERSION") ?? "1.0.0"; // Default to 1.0.0 if not set
+            var version = Assembly.GetExecutingAssembly()
+                                 .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+                         ?? Assembly.GetExecutingAssembly().GetName().Version?.ToString()
+                         ?? "1.0.0";
             return View("Default", version);
         }
     }

--- a/src/apps/App.Web.Client/Views/Account/Unauthorized.cshtml
+++ b/src/apps/App.Web.Client/Views/Account/Unauthorized.cshtml
@@ -1,0 +1,60 @@
+﻿@{
+    ViewData["Title"] = "Unauthorized";
+    var headers = Context.Request.Headers;
+    var user = Context.User;
+    bool isAuthenticated = user?.Identity?.IsAuthenticated ?? false;
+    var claims = user?.Claims?.ToList() ?? new List<Claim>();
+}
+
+<h2>Unauthorized</h2>
+<p>
+    @if (isAuthenticated)
+    {
+        <span>You are logged in</span>
+    }
+    else
+    {
+        <span>You are not logged in.</span>
+    }
+</p>
+
+@if (isAuthenticated && claims.Any())
+{
+    <h3>User Claims</h3>
+    <table class="table table-bordered">
+        <thead>
+            <tr>
+                <th>Type</th>
+                <th>Value</th>
+            </tr>
+        </thead>
+        <tbody>
+        @foreach (var claim in claims)
+        {
+            <tr>
+                <td>@claim.Type</td>
+                <td>@claim.Value</td>
+            </tr>
+        }
+        </tbody>
+    </table>
+}
+
+<h3>Request Headers</h3>
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th>Header</th>
+            <th>Value</th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach (var header in headers)
+    {
+        <tr>
+            <td>@header.Key</td>
+            <td>@string.Join(", ", header.Value)</td>
+        </tr>
+    }
+    </tbody>
+</table>

--- a/src/apps/App.Web.Client/Views/_ViewImports.cshtml
+++ b/src/apps/App.Web.Client/Views/_ViewImports.cshtml
@@ -6,3 +6,4 @@
 @using App.Web.Client.Utilities.CustomViewComponent
 @using Microsoft.AspNetCore.Html
 @using App.Common.Domain.Dtos
+@using System.Security.Claims

--- a/src/apps/App.Web.Client/appsettings.json
+++ b/src/apps/App.Web.Client/appsettings.json
@@ -6,10 +6,11 @@
     }
   },
   "AllowedHosts": "*",
+  "UseEasyAuth": false,
   "AzureEntra": {
-        "Authority": "https://login.microsoftonline.com/7d49edce-eda8-4d56-8fe8-04390a0eb982/v2.0",
-        "TenantId": "7d49edce-eda8-4d56-8fe8-04390a0eb982",
-        "ClientId": "beedb05b-78f1-4917-a0c8-271cf7188ac3",
-        "CallbackPath": "/signin-oidc"
-    }
+    "Authority": "https://login.microsoftonline.com/7d49edce-eda8-4d56-8fe8-04390a0eb982/v2.0",
+    "TenantId": "7d49edce-eda8-4d56-8fe8-04390a0eb982",
+    "ClientId": "beedb05b-78f1-4917-a0c8-271cf7188ac3",
+    "CallbackPath": "/signin-oidc"
+  }
 }


### PR DESCRIPTION
## 🚀 Summary

Azure Container Apps terminates HTTPS at its ingress/load balancer and forwards requests to the app container over plain HTTP.
By default, ASP.NET Core constructs redirect URLs based on the incoming request protocol — which appears as http.
As a result, redirect URIs sent to Azure Entra ID are incorrectly generated with the http:// scheme instead of https://. 
To fix this, the Forwarded Headers Middleware must be enabled so the app respects the original protocol (e.g., https) as seen by Azure’s ingress proxy. This ensures that redirect URIs generated for Entra authentication use the correct scheme.


## 🔧 Changes

- Enabled ASP.NET Core's ForwardedHeadersMiddleware to handle forwarded protocol and host headers from Azure Container Apps.

---

## 🧪 Testing

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual verification

## 📎 Additional Notes

- Link to related issues or tickets : #31 
---

## ✅ Checklist

- [x] Code builds successfully
- [z] Tests pass locally
- [ ] Follows coding guidelines
- [ ] Relevant documentation updated (if needed)
