### PR TITLE
Add Resiliency with Polly

### DIFF
--- a/src/apps/App.Web.UI/App.Web.UI.csproj
+++ b/src/apps/App.Web.UI/App.Web.UI.csproj
@@ -18,8 +18,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.21" />
     <PackageReference Include="Microsoft.Identity.Web" Version="3.8.4" />
     <PackageReference Include="Microsoft.Identity.Web.UI" Version="3.8.4" />
+    <PackageReference Include="Polly" Version="8.6.4" />
   </ItemGroup>
 
 </Project>

--- a/src/apps/App.Web.UI/Utilities/Http/Resiliency/HttpClientResilienceOptions.cs
+++ b/src/apps/App.Web.UI/Utilities/Http/Resiliency/HttpClientResilienceOptions.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace App.Web.UI.Utilities.Http.Resiliency;
+
+public class HttpClientResilienceOptions
+{
+    public int MaxRetries { get; set; } = 3;
+    public TimeSpan RetryDelay { get; set; } = TimeSpan.FromSeconds(2);
+    public int CircuitBreakerFailures { get; set; } = 5;
+    public TimeSpan CircuitBreakerDelay { get; set; } = TimeSpan.FromSeconds(30);
+    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(30);
+}

--- a/src/apps/App.Web.UI/Utilities/Http/Resiliency/ResiliencePolicyFactory.cs
+++ b/src/apps/App.Web.UI/Utilities/Http/Resiliency/ResiliencePolicyFactory.cs
@@ -1,0 +1,81 @@
+using System.Net.Sockets;
+using Polly;
+using Polly.Extensions.Http;
+using Polly.Timeout;
+
+namespace App.Web.UI.Utilities.Http.Resiliency;
+
+public static class ResiliencePolicyFactory
+{
+    public static IAsyncPolicy<HttpResponseMessage> CreatePolicy(
+            HttpClientResilienceOptions options,
+            ILogger logger)
+    {
+        return Policy.WrapAsync(
+            CreateCircuitBreakerPolicy(options, logger),
+            Policy.WrapAsync(
+                CreateRetryPolicy(options, logger),
+                CreateTimeoutPolicy(options, logger)
+            )
+        );
+    }
+
+    private static IAsyncPolicy<HttpResponseMessage> CreateCircuitBreakerPolicy(
+        HttpClientResilienceOptions options,
+        ILogger logger)
+    {
+        return HttpPolicyExtensions
+            .HandleTransientHttpError()
+            .Or<SocketException>()
+            .Or<TimeoutRejectedException>()
+            .CircuitBreakerAsync(
+                options.CircuitBreakerFailures,
+                options.CircuitBreakerDelay,
+                onBreak: (outcome, duration) =>
+                {
+                    logger.LogWarning(outcome.Exception,
+                        "Circuit breaker opened for {Duration}s. Error: {Error}",
+                        duration.TotalSeconds,
+                        outcome.Exception?.Message ?? "Unknown error");
+                },
+                onReset: () =>
+                {
+                    logger.LogInformation("Circuit breaker reset");
+                },
+                onHalfOpen: () =>
+                {
+                    logger.LogInformation("Circuit breaker half-open");
+                });
+    }
+
+    private static IAsyncPolicy<HttpResponseMessage> CreateRetryPolicy(
+        HttpClientResilienceOptions options,
+        ILogger logger)
+    {
+        return HttpPolicyExtensions
+            .HandleTransientHttpError()
+            .Or<SocketException>()
+            .Or<TimeoutRejectedException>()
+            .WaitAndRetryAsync(
+                options.MaxRetries,
+                retryAttempt =>
+                    TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)) +
+                    TimeSpan.FromMilliseconds(Random.Shared.Next(0, 100)),
+                onRetry: (outcome, timeSpan, retryCount, context) =>
+                {
+                    logger.LogWarning(outcome.Exception,
+                        "Retry {RetryCount} after {Delay}s. Error: {Error}",
+                        retryCount,
+                        timeSpan.TotalSeconds,
+                        outcome.Exception?.Message ?? "Unknown error");
+                }
+            );
+    }
+
+    private static IAsyncPolicy<HttpResponseMessage> CreateTimeoutPolicy(
+        HttpClientResilienceOptions options,
+        ILogger logger)
+    {
+        return Policy.TimeoutAsync<HttpResponseMessage>(options.Timeout);
+    }
+}

--- a/src/apps/App.Web.UI/Utilities/Http/Todo/TodoApiAuthHandler.cs
+++ b/src/apps/App.Web.UI/Utilities/Http/Todo/TodoApiAuthHandler.cs
@@ -2,7 +2,7 @@ using System.Net.Http.Headers;
 using App.Web.UI.Utilities.Http.Token;
 using static App.Web.UI.Utilities.Enums.Constant;
 
-namespace App.Web.UI.Utilities.Http;
+namespace App.Web.UI.Utilities.Http.Todo;
 
 public class TodoApiAuthHandler : DelegatingHandler
 {

--- a/src/apps/App.Web.UI/Utilities/Http/Todo/TodoApiClient.cs
+++ b/src/apps/App.Web.UI/Utilities/Http/Todo/TodoApiClient.cs
@@ -16,8 +16,20 @@ public class TodoApiClient : BaseApiClient, ITodoApiClient
 
     public async Task<PagedResult<TodolistDto>> GetTodosAsync(int pageNumber = 1, int pageSize = 10, string orderBy = "createdAt", CancellationToken cancellationToken = default)
     {
-        var query = $"page={pageNumber}&pageSize={pageSize}&orderBy={orderBy}";
+        var result = new PagedResult<TodolistDto>();
 
-        return await GetAsync<TodolistDto>("/todos", query, cancellationToken);
+        try
+        {
+            var query = $"page={pageNumber}&pageSize={pageSize}&orderBy={orderBy}";
+
+            result = await GetAsync<TodolistDto>("/todos", query, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error occurred while fetching todos");
+        }
+
+        return result;
+
     }
 }


### PR DESCRIPTION
## 🚀 Summary

This PR introduces a resilient HTTP handler using Polly.
It includes the following resilience strategies:

- Retry Policy – to handle transient failures with exponential backoff.
- Timeout Policy – to prevent long-running requests from hanging indefinitely.
- Circuit Breaker Policy – to stop sending requests when consecutive failures exceed the defined threshold.

---

## 🔧 Changes

- The resilience policies are configured through HttpClientResilienceOptions in app settings.
- Registered in AddHttpClients via IServiceCollection extension.
- Policies are composed using Policy.WrapAsync() for layered resiliency.
- Logging integrated to capture retry and circuit breaker events.
- Applied to ITodoApiClient via AddHttpMessageHandler<TodoApiAuthHandler>().

---

## 🧪 Testing

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual verification

---

## ✅ Checklist

- [ ] Code builds successfully
- [ ] Tests pass locally
- [ ] Follows coding guidelines
- [ ] Relevant documentation updated (if needed)
